### PR TITLE
fixing `echo` command for creating %echo in desk.bill

### DIFF
--- a/asl-2023.1/asl4.md
+++ b/asl-2023.1/asl4.md
@@ -257,7 +257,7 @@ We also need to an a `desk.docket-0` file to the root of the desk to configure t
 **`desk.bill`**
 
 ```sh
-$ echo "~[%echo]" > echo/desk/desk.bill
+$ echo "~[%echo]" > echo/desk.bill
 ```
 
 Finally, we will also need the docket marks, which are not in `%base` but we can get from `%garden`:


### PR DESCRIPTION
Looks like the original creates an excess `/desk` directory?