### PR TITLE
Fixing typos in desk.docket-0 section

### DIFF
--- a/asl-2023.1/asl4.md
+++ b/asl-2023.1/asl4.md
@@ -240,13 +240,13 @@ This is a copy of the latest `%delta` except for name changes.  More sophisticat
 
 **`desk.docket-0`**
 
-We also need to an a `desk.docket-0` file to the root of the desk to configure the app tile and source of front-end files:
+We also need to add a `desk.docket-0` file to the root of the desk to configure the app tile and source of front-end files:
 
 ```hoon
 :~  title+'%echo'                                                                                    
     info+'A stack of numbers'
     color+0x2e.4347
-    glob-http+['https://bootstrap.urbit.org/glob-0v5.hurm4.ejod5.ngg9h.iub9i.n1j7o.glob' 0v5.hurm4.ejo  d5.ngg9h.iub9i.n1j7o]
+    glob-http+['https://bootstrap.urbit.org/glob-0v5.hurm4.ejod5.ngg9h.iub9i.n1j7o.glob' 0v5.hurm4.ejod5.ngg9h.iub9i.n1j7o]
     base+'echo'
     version+[0 0 1]
     website+'https://github.com'


### PR DESCRIPTION
Typo in language of line 243

Plus a `gap` in line 249 ends up crashing the attempt to `|commit %echo` with the following: 
```
> |commit %echo
>=
crud: %into event failed
[%poke %into]
bar-stack=~[~[//sync/0v1s.qh535]]
call: failed
[ from=2
  deletes={}
    changes
  { [i=~.desk t=/bill]
    [i=~.mar t=/echo/update/hoon]
    [i=~.mar t=/echo/action/hoon]
    [i=~.desk t=/docket-0]
    [i=~.sur t=/docket/hoon]
    [i=~.lib t=/docket/hoon]
    [i=~.app t=/echo-follower/hoon]
    [i=~.sur t=/echo/hoon]
    [i=~.mar t=/docket-0/hoon]
    [i=~.app t=/echo/hoon]
  }
]
[%error-validating /desk/docket-0]
[%validate-page-fail /desk/docket-0 %from %mime]
/mar/docket-0/hoon:<[16 5].[19 51]>
/mar/docket-0/hoon:<[17 5].[19 51]>
/mar/docket-0/hoon:<[18 5].[19 51]>
/mar/docket-0/hoon:<[19 5].[19 51]>
/mar/docket-0/hoon:<[19 27].[19 50]>
/mar/docket-0/hoon:<[19 39].[19 49]>
{4 103}
syntax error
```

This was a little tricky to figure out since it pointed me to the `mar` file which was just copy pasted over from `%garden` but the actual error was in the `desk.docket-0`. ngl, I feel a little accomplished. But hopefully other people don't snag on this as I did :)